### PR TITLE
Update repository field to new git repository

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "watch": "tsc --watch -p tsconfig.json",
     "prepublish": "yarn build"
   },
-  "repository": "CompuIves/codesandbox-cli",
+  "repository": "codesandbox-app/codesandbox-importers",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
Small change so finding the CLI on npm directs you here instead of to the archived repository.