### PR TITLE
Fix path scanning for Windows

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -92,7 +92,7 @@ export default function registerCommand(program: typeof Commander) {
 
       info(`Deploying ${path} to CodeSandbox`);
       try {
-        let resolvedPath = join(process.cwd(), path);
+        let resolvedPath = join("./", path);
 
         if (resolvedPath.endsWith("/")) {
           resolvedPath = resolvedPath.slice(0, -1);


### PR DESCRIPTION
Problem: `process.cwd()` returns an absolute path on Windows, which breaks downstream processing of files and directories.
Fix: Replace `join(process.cwd(), path);` with `join("./", path);` before reading all files/directories with fs.readDir.

Fixes CompuIves/codesandbox-client#691