### PR TITLE
Fix main file path error in Windows

### DIFF
--- a/packages/import-utils/src/create-sandbox/index.ts
+++ b/packages/import-utils/src/create-sandbox/index.ts
@@ -67,7 +67,8 @@ export default async function createSandbox(
   const packageJsonPackage = JSON.parse(packageJson.content);
 
   const template = getTemplate(packageJsonPackage, directory);
-  const mainFile = findMainFile(directory, packageJsonPackage.main, template);
+  const mainFileUnix = findMainFile(directory, packageJsonPackage.main, template);
+  const mainFile = process.platform === "win32" ? mainFileUnix.replace(/\//g, "\\") : mainFileUnix;
 
   if (!directory[mainFile]) {
     throw new Error(


### PR DESCRIPTION
Like I said, this is a minimal solution to issue #10. Another approach (but longer) could be making sure all of the paths in `directory` are Unix-like ahead of time, then a platform check wouldn't be neccessary.

If you'd like to have some automated tests for this let me know.

Closes #10 
