### PR TITLE
add support for Dojo 3+

### DIFF
--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -75,7 +75,7 @@ export function getTemplate(
     return "vue-cli";
   }
 
-  if (totalDependencies.indexOf("@dojo/core") > -1) {
+  if (totalDependencies.indexOf("@dojo/core") > -1 || totalDependencies.indexOf("@dojo/framework") > -1) {
     return "@dojo/cli-create-app";
   }
 


### PR DESCRIPTION
Dojo is deprecating the use of @dojo/core as it has been merged into a new @dojo/framework package going forward. Add a check for this package to know to use the @dojo/cli-create-app template. This fixes compuives/codesandbox-client#988.