### PR TITLE
Update Template Inference for Apollo, Nuxt, Dojo

### DIFF
--- a/packages/import-utils/src/create-sandbox/templates.ts
+++ b/packages/import-utils/src/create-sandbox/templates.ts
@@ -75,18 +75,26 @@ export function getTemplate(
     ...Object.keys(devDependencies)
   ];
 
-  if (
-    totalDependencies.indexOf("nuxt") > -1 ||
-    totalDependencies.indexOf("nuxt-edge") > -1
-  ) {
+  const nuxt = ["nuxt", "nuxt-edge"]
+  
+  if (totalDependencies.some(dep => nuxt.includes(dep))) {
     return "nuxt";
   }
 
   if (totalDependencies.indexOf("next") > -1) {
     return "next";
   }
+  
+  const apollo = [
+    "apollo-server",
+    "apollo-server-express",
+    "apollo-server-hapi",
+    "apollo-server-koa",
+    "apollo-server-lambda",
+    "apollo-server-micro"
+  ]
 
-  if (totalDependencies.indexOf("apollo-server") > -1) {
+  if (totalDependencies.some(dep => apollo.includes(dep))) {
     return "apollo";
   }
 
@@ -130,11 +138,10 @@ export function getTemplate(
   if (totalDependencies.indexOf("vue") > -1) {
     return "vue-cli";
   }
-
-  if (
-    totalDependencies.indexOf("@dojo/core") > -1 ||
-    totalDependencies.indexOf("@dojo/framework") > -1
-  ) {
+  
+  const dojo = ["@dojo/core", "@dojo/framework"]
+  
+  if (totalDependencies.some(dep => dojo.includes(dep))) {
     return "@dojo/cli-create-app";
   }
 


### PR DESCRIPTION
Changed template inference for Apollo, Nuxt and Dojo to use the pattern `totalDependencies.some(dep => <dependenciesList>.includes(dep))` to check against a list of package names, which is the equivalent to multiple OR conditionals.

some() will return true if one or more items in the callback returns true, and includes() will return true if an item exists within an array.

For each template that could match against multiple packages, those packages have been placed in their own list, for example:

```javascript
const nuxt = ["nuxt", "nuxt-edge"]

if (totalDependencies.some(dep => nuxt.includes(dep))) {
  return "nuxt";
}
```

Because apollo-server has multiple different packages to support different server frameworks (such as Express, Hapi, Koa, etc), a list has been added for those packages so that sandboxes which include them will be properly inferred to have the Apollo template. This is necessary to support importing Apollo server repositories from GitHub. Currently if you use the existing Apollo template and change it's dependencies to use a different variant, such as apollo-server-lambda, the sandbox will automatically switch to the Node template. Upon exporting to GitHub from CodeSandbox and re-importing, the template then defaults to create-react-app, which is not the desired behavior, as the sandbox environment is no longer a server sandbox.

Please see the following sandboxes for reference:

https://codesandbox.io/s/github/Saeris/Apollo-Server-Lambda-CodeSandbox-Template/tree/master

https://codesandbox.io/s/4m9l3o6rw