### PR TITLE
Fixed chalk import

### DIFF
--- a/packages/cli/src/utils/log.ts
+++ b/packages/cli/src/utils/log.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import * as chalk from "chalk";
 
 export function log(text = "") {
   console.log(`> ${text}`);

--- a/packages/cli/src/utils/parse-sandbox/index.ts
+++ b/packages/cli/src/utils/parse-sandbox/index.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import * as chalk from "chalk";
 import * as fs from "fs-extra";
 import * as inquirer from "inquirer";
 import * as path from "path";


### PR DESCRIPTION
Should fix this issue: https://github.com/codesandbox-app/codesandbox-importers/issues/20

Nine days ago (in v.1.3.2) chalk was changed from `import * chalk from "chalk"` to `import chalk from "chalk"`. After TypeScript transpilation, `chalk` === `undefined`, leading to the dreaded...

**TypeError: Cannot read property 'blue' of undefined**.