### PR TITLE
Correction CLI does not work without GH

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,7 +29,7 @@ codesandbox ./
 ## Current limitations
 
 - You need to be signed in to GitHub, this is to prevent abuse
-- Accounts without the Github integration setup cannot use this tool
+- Accounts without the GitHub integration setup cannot use this tool
 - You cannot sign in with Google
 
 ## Inspiration


### PR DESCRIPTION
The CLI is the go to tool for people on Gitter, Bitbucket, Gitlab OSS, Gitlab.com and other Git repositories... yet, it requires a GitHub account to use. The readme does not mention this. The alternatives are extremely painful due to the 50 file quota on CSB's container sync.