### PR TITLE
feat: add support for parsing environment variables

### DIFF
--- a/packages/git-extractor/package.json
+++ b/packages/git-extractor/package.json
@@ -61,6 +61,7 @@
     "babylon": "^6.18.0",
     "base-64": "^0.1.0",
     "debug": "^2.6.8",
+    "envfile": "^7.1.0",
     "gitignore-parser": "^0.0.2",
     "humps": "CompuIves/humps",
     "istextorbinary": "^6.0.0",

--- a/packages/import-utils/src/create-sandbox/index.ts
+++ b/packages/import-utils/src/create-sandbox/index.ts
@@ -5,6 +5,7 @@ import {
   ITemplate,
 } from "codesandbox-import-util-types";
 import denormalize from "../utils/files/denormalize";
+import { parse as parseEnv } from "envfile";
 
 import parseHTML from "./html-parser";
 import { getMainFile, getTemplate } from "./templates";
@@ -71,9 +72,7 @@ function isCloudTemplate(template: ITemplate): boolean {
   return CLOUD_TEMPLATES.indexOf(template) > -1;
 }
 
-function getSandboxMetadata(
-  directory: INormalizedModules
-): {
+function getSandboxMetadata(directory: INormalizedModules): {
   title: string;
   description: string;
   tags: string[];
@@ -106,6 +105,20 @@ function getSandboxMetadata(
   }
 
   return packageJsonInfo;
+}
+
+/**
+ * Gets the prefilled environment variables by parsing either /.env.example
+ * or /.env.
+ */
+function getEnvironmentVariables(directory: INormalizedModules) {
+  const envFile = directory[".env"] || directory[".env.example"];
+
+  if (!envFile || envFile.type !== "file") {
+    return {};
+  }
+
+  return parseEnv(envFile.content);
 }
 
 /**
@@ -160,6 +173,7 @@ export default async function createSandbox(
     modules,
     directories,
     externalResources: [],
+    environmentVariables: getEnvironmentVariables(directory),
     template,
     entry: mainFile,
     v2: isCloudTemplate(template),

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -73,6 +73,7 @@ export interface ISandbox {
   externalResources: string[];
   template: ITemplate;
   entry: string;
+  environmentVariables: Record<string, string>;
   v2?: boolean;
   templateParams?: {
     iconUrl?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3719,6 +3719,11 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
+envfile@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/envfile/-/envfile-7.1.0.tgz#c0b101279dc710c25546602d5d17cfb9ab132e48"
+  integrity sha512-dyH4QnnZsArCLhPASr29eqBWDvKpq0GggQFTmysTT/S9TTmt1JrEKNvTBc09Cd7ujVZQful2HBGRMe2agu7Krg==
+
 envinfo@7.8.1:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"


### PR DESCRIPTION
When templates on GitHub define a `/.env.example`, we want to make it possible for users to specify the new environment variables when forking those templates. To do this, we need to encode in the sandbox/devbox which environment variables are used, on a database level.

With this change, we return the environment variables to the server so it can render this in the UI.